### PR TITLE
Honor pre-set slugs and refine slug generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to `sluggable` will be documented in this file.
 
+## 1.1.5 - 2025-09-06
+- **Enhancement:** Added a string type hint to `findBySlug` for improved static analysis.
+- **Feature:** Slug generation now respects manually set slugs and skips automatic generation when a slug already exists.
+- **Change:** Removed the `'default'` fallback in `getSlugSource`, preventing unintended slugs when no source is available.
+
 ## 1.1.4 - 2025-08-26
 - **Change:** Dropped support for Laravel 11; package now targets Laravel 12 and newer.
 - **Change:** Bumped minimum PHP version requirement to 8.4.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ class Post extends Model
 }
 ```
 
+### Manually Setting Slugs
+
+If you assign a value to the slug column before saving, the trait will honor it and skip automatic generation:
+
+```php
+$post = new Post(['title' => 'My Title']);
+$post->slug = 'custom-slug';
+$post->save();
+// $post->slug remains 'custom-slug'
+```
+
 ## 2. Migrate the Slug Column
 
 Ensure your table has a suitable column for the slug:

--- a/src/Traits/Sluggable.php
+++ b/src/Traits/Sluggable.php
@@ -30,7 +30,7 @@ trait Sluggable
      * @param  string  $slug
      * @return Model|null
      */
-    public static function findBySlug($slug): ?Model
+     public static function findBySlug(string $slug): ?Model
     {
         $column = (new static)->getSlugColumn();
 
@@ -58,6 +58,12 @@ trait Sluggable
 
         // Determine which field we use as slug source
         $sourceField = $this->determineSourceField();
+
+        // If the slug column already has a value, honor it and skip generation
+        $slugColumn = $this->getSlugColumn();
+        if (! empty($this->{$slugColumn})) {
+            return;
+        }
 
         // If it's an update, check if the source field is actually dirty
         if ($onUpdate && ! $this->isDirty($sourceField)) {
@@ -109,7 +115,7 @@ trait Sluggable
         return $this->{$sourceField}
             ?? $this->title
             ?? $this->name
-            ?? 'default';
+            ?? '';
     }
 
     /**

--- a/tests/Unit/SluggableTest.php
+++ b/tests/Unit/SluggableTest.php
@@ -36,3 +36,15 @@ it('updates the slug on update', function () {
 
     $this->assertEquals('hello-universe', $post->slug);
 });
+
+it('respects a manually set slug', function () {
+    $post = new Post(['title' => 'Hello World']);
+    $post->slug = 'custom-slug';
+    $post->save();
+
+    $this->assertEquals('custom-slug', $post->slug);
+
+    $post->update(['title' => 'Hello Universe']);
+
+    $this->assertEquals('custom-slug', $post->slug);
+});


### PR DESCRIPTION
## Summary
- add string type hint to `findBySlug`
- skip slug regeneration when a model already has a slug
- remove `default` fallback when resolving slug source
- document manual slug usage and update changelog
- fix changelog order so version `1.1.5` precedes `1.1.4`

## Testing
- `php composer.phar install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5b28e8b4832cbc3e8489d05a7878