### PR TITLE
Add stub publish support and coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to `sluggable` will be documented in this file.
 
+## 1.1.5 - 2025-09-23
+- **Fix:** Added publishable action stub mapping and template to restore `vendor:publish --tag=actions-stubs` support.
+- **Tests:** Added coverage to ensure the action stub publishes successfully.
+
 ## 1.1.4 - 2025-08-26
 - **Change:** Dropped support for Laravel 11; package now targets Laravel 12 and newer.
 - **Change:** Bumped minimum PHP version requirement to 8.4.

--- a/src/SluggableServiceProvider.php
+++ b/src/SluggableServiceProvider.php
@@ -17,6 +17,11 @@ class SluggableServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../config/sluggable.php' => config_path('sluggable.php'),
         ], 'config');
+
+        // Publish the action stub
+        $this->publishes([
+            __DIR__.'/../stubs/action.stub' => base_path('stubs/action.stub'),
+        ], 'actions-stubs');
     }
 
     /**

--- a/stubs/action.stub
+++ b/stubs/action.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace {{ namespace }};
+
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class {{ class }}
+{
+    use AsAction;
+
+    public function handle()
+    {
+        //
+    }
+}

--- a/tests/Feature/SluggableTest.php
+++ b/tests/Feature/SluggableTest.php
@@ -14,6 +14,21 @@ it('can publish the configuration file', function () {
     $this->assertFileExists(config_path('sluggable.php'));
 });
 
+it('can publish the action stub', function () {
+    $stubPath = base_path('stubs/action.stub');
+
+    if (file_exists($stubPath)) {
+        unlink($stubPath);
+    }
+
+    $this->artisan('vendor:publish', [
+        '--provider' => 'AesirCloud\Sluggable\SluggableServiceProvider',
+        '--tag' => 'actions-stubs',
+    ])->assertExitCode(0);
+
+    $this->assertFileExists($stubPath);
+});
+
 it('merges the configuration file', function () {
     $config = config('sluggable.source');
     expect($config)->toBe('title');


### PR DESCRIPTION
## Summary
- add publishable action stub to the service provider
- include an action stub template for publishing
- add Pest coverage to ensure the stub can be published

## Testing
- ⚠️ `php composer.phar install` *(fails: CONNECT tunnel failed, response 403 while downloading packages)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692337dfc558832cba00289b8339812b)